### PR TITLE
Refactor: Change player movement scale from kilometers to meters.

### DIFF
--- a/images/.gitkeep
+++ b/images/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank to ensure the directory is tracked by Git.
+# You can remove this file once actual images are added to this folder.

--- a/index.html
+++ b/index.html
@@ -679,7 +679,7 @@
 
         // Calculate distance between two points
         function calculateDistance(pos1, pos2) {
-            const R = 6371; // Earth's radius in km
+            const R = 6371000; // Earth's radius in m
             const dLat = (pos2[0] - pos1[0]) * Math.PI / 180;
             const dLon = (pos2[1] - pos1[1]) * Math.PI / 180;
             const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
@@ -704,7 +704,7 @@
                 eventCounter: 0
             };
             
-            const baseSpeed = gameState.character.speed / 10; // Convert to km per step
+            const baseSpeed = gameState.character.speed * 100; // Convert to m per step (original speed was km/step, now m/step)
             
             updateTravelInfo(gameState.journeyData.totalDistance, gameState.journeyData.distanceTraveled);
             
@@ -741,7 +741,7 @@
         function updateTravelInfo(totalDistance, distanceTraveled) {
             const progress = (distanceTraveled / totalDistance) * 100;
             document.getElementById('travelInfo').textContent = 
-                `Distance: ${distanceTraveled.toFixed(1)}/${totalDistance.toFixed(1)} km`;
+                `Distance: ${distanceTraveled.toFixed(0)}/${totalDistance.toFixed(0)} m`;
             document.getElementById('progressFill').style.width = progress + '%';
         }
 
@@ -756,7 +756,7 @@
         // Resume movement after event
         function resumeMovement() {
             if (gameState.isMoving && !gameState.moveInterval && gameState.destination && gameState.journeyData) {
-                const baseSpeed = gameState.character.speed / 10;
+                const baseSpeed = gameState.character.speed * 100; // Convert to m per step (original speed was km/step, now m/step)
                 
                 gameState.moveInterval = setInterval(() => {
                     const stepDistance = Math.min(baseSpeed, gameState.journeyData.totalDistance - gameState.journeyData.distanceTraveled);


### PR DESCRIPTION
This commit updates the player movement calculations and display to use meters instead of kilometers.

Key changes:
- I modified `calculateDistance` to return distance in meters.
- I adjusted `baseSpeed` in `startMovement` and `resumeMovement` to maintain consistent travel speed, now calculated in meters per step.
- I updated `updateTravelInfo` to display travel distances in meters.
- I created a new empty `images` folder at the repository root for future use, including a `.gitkeep` file to ensure it's tracked by Git.