### PR TITLE
feat: Adjust map zoom and player speed for exploration

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,7 +626,7 @@
         function initMap() {
             gameState.map = L.map('map', {
                 zoomControl: false // Remove default zoom controls
-            }).setView(gameState.currentPosition, 10);
+            }).setView(gameState.currentPosition, 18);
             
             // Add zoom control to bottom right
             L.control.zoom({
@@ -704,7 +704,7 @@
                 eventCounter: 0
             };
             
-            const baseSpeed = gameState.character.speed * 100; // Convert to m per step (original speed was km/step, now m/step)
+            const baseSpeed = gameState.character.speed * 10; // Convert to m per step (original speed was km/step, now m/step)
             
             updateTravelInfo(gameState.journeyData.totalDistance, gameState.journeyData.distanceTraveled);
             
@@ -756,7 +756,7 @@
         // Resume movement after event
         function resumeMovement() {
             if (gameState.isMoving && !gameState.moveInterval && gameState.destination && gameState.journeyData) {
-                const baseSpeed = gameState.character.speed * 100; // Convert to m per step (original speed was km/step, now m/step)
+                const baseSpeed = gameState.character.speed * 10; // Convert to m per step (original speed was km/step, now m/step)
                 
                 gameState.moveInterval = setInterval(() => {
                     const stepDistance = Math.min(baseSpeed, gameState.journeyData.totalDistance - gameState.journeyData.distanceTraveled);


### PR DESCRIPTION
I increased the default map zoom level from 10 to 18 in `initMap` to ensure the map is played at a "full zoom" level as you requested.

I reduced the player's base movement speed multiplier by a factor of 10 (from 100 to 10 in `startMovement` and `resumeMovement` functions). This change, combined with the increased zoom, makes the player move significantly slower relative to the visible map area, enhancing the feeling of exploration.

The distance calculations remain accurate (in meters). The reduced speed means each movement step covers less ground, making events trigger more frequently over a given distance, which aligns with more detailed exploration of an area.